### PR TITLE
Update host pool module to support new variable usage for custom rdp properties

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Create Azure Virtual Desktop host pool
 module "avm_res_desktopvirtualization_hostpool" {
   source  = "Azure/avm-res-desktopvirtualization-hostpool/azurerm"
-  version = ">=0.3.0"
+  version = ">=0.4.0"
 
   resource_group_name                                = var.resource_group_name
   virtual_desktop_host_pool_load_balancer_type       = var.virtual_desktop_host_pool_load_balancer_type

--- a/variables.tf
+++ b/variables.tf
@@ -335,9 +335,52 @@ EOT
 }
 
 variable "virtual_desktop_host_pool_custom_rdp_properties" {
-  type        = string
-  default     = "drivestoredirect:s:*;audiomode:i:0;videoplaybackmode:i:1;redirectclipboard:i:1;redirectprinters:i:1;devicestoredirect:s:*;redirectcomports:i:1;redirectsmartcards:i:1;usbdevicestoredirect:s:*;enablecredsspsupport:i:1;use multimon:i:0"
-  description = "(Optional) A valid custom RDP properties string for the Virtual Desktop Host Pool, available properties can be [found in this article](https://docs.microsoft.com/windows-server/remote/remote-desktop-services/clients/rdp-files)."
+  type = object({
+    drivestoredirect     = optional(string, "*")
+    audiomode            = optional(number, 0)
+    videoplaybackmode    = optional(number, 1)
+    redirectclipboard    = optional(number, 1)
+    redirectprinters     = optional(number, 1)
+    devicestoredirect    = optional(string, "*")
+    redirectcomports     = optional(number, 1)
+    redirectsmartcards   = optional(number, 1)
+    usbdevicestoredirect = optional(string, "*")
+    enablecredsspsupport = optional(number, 1)
+    use_multimon         = optional(number, 0)
+    custom_properties    = optional(map(string), {})
+  })
+  default = {
+    drivestoredirect     = "*"
+    audiomode            = 0
+    videoplaybackmode    = 1
+    redirectclipboard    = 1
+    redirectprinters     = 1
+    devicestoredirect    = "*"
+    redirectcomports     = 1
+    redirectsmartcards   = 1
+    usbdevicestoredirect = "*"
+    enablecredsspsupport = 1
+    use_multimon         = 0
+    custom_properties    = {}
+  }
+  description = <<-DESCRIPTION
+    (Optional) Custom RDP properties for the Virtual Desktop Host Pool. 
+    Configure individual RDP settings or provide additional custom properties.
+    Available properties can be found in: https://docs.microsoft.com/windows-server/remote/remote-desktop-services/clients/rdp-files
+    
+    - drivestoredirect: Drive redirection (string, default: "*")
+    - audiomode: Audio mode (number: 0=Both, 1=Local, 2=Remote, default: 0)
+    - videoplaybackmode: Video playback mode (number: 0=Disabled, 1=Enabled, default: 1)
+    - redirectclipboard: Clipboard redirection (number: 0=Disabled, 1=Enabled, default: 1)
+    - redirectprinters: Printer redirection (number: 0=Disabled, 1=Enabled, default: 1)
+    - devicestoredirect: Device redirection (string, default: "*")
+    - redirectcomports: COM port redirection (number: 0=Disabled, 1=Enabled, default: 1)
+    - redirectsmartcards: Smart card redirection (number: 0=Disabled, 1=Enabled, default: 1)
+    - usbdevicestoredirect: USB device redirection (string, default: "*")
+    - enablecredsspsupport: CredSSP support (number: 0=Disabled, 1=Enabled, default: 1)
+    - use_multimon: Multi-monitor support (number: 0=Disabled, 1=Enabled, default: 0)
+    - custom_properties: Additional custom RDP properties as key-value pairs
+  DESCRIPTION
 }
 
 # tflint-ignore: terraform_unused_declarations


### PR DESCRIPTION
## Description

Update module to support breaking change introduced downstream but host pool module.

there is now an object for custom rdp properties which wasnt there before

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
